### PR TITLE
復帰の実装（いくつか問題あり）

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,7 +1,19 @@
 {
-  "requires": true,
+  "name": "backend",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -123,6 +135,22 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -367,6 +395,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
       "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
     },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -409,6 +445,11 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -666,6 +707,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -673,6 +719,25 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.3.tgz",
+      "integrity": "sha512-YbEHRs7bYOBTIWedTR9koVEe2mXrq+xdjTJZcoKJK/pQaE6ni28ak2AKXFpevb+X6w3iU5SXzWDiJkmpDRb9qw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.4.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "universal-cookie-express": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/universal-cookie-express/-/universal-cookie-express-4.0.3.tgz",
+      "integrity": "sha512-hDZW9UsRpFMdbtC0JjgTMfwEp42gGWLD5Q9qkS72cogLAqX6SyWK9klWAZWsNSNkInZZrPlRQhQie79qFugZSQ==",
+      "requires": {
+        "universal-cookie": "^4.0.0"
       }
     },
     "unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cookies": "^0.8.0",
     "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "socket.io": "^2.3.0",
+    "universal-cookie-express": "^4.0.3"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,15 +21,15 @@ const round_end = require('./src/scripts/stage/round_end');
 const disconnect = require('./src/scripts/stage/disconnect');
 // const fs = require('fs');
 const socketIO = require('socket.io');
-const app = express();
-const server = http.Server(app);
+// const app = express();
+const server = http.Server();
 const io = socketIO(server);
 
 // ゲームオブジェクト作成
 let game = new Game();
 // 接続が完了したときに呼び出す関数
-io.on('connection', function(socket) {
-    //行動する必要がない時
+io.on('connection', (socket) => {
+    // 行動する必要がない時
     socket.on('wait', () => wait.do(socket, game));
     // クライアント接続時
     socket.on('init', (config) => init.do(config, io, socket, game));
@@ -37,20 +37,20 @@ io.on('connection', function(socket) {
     socket.on('entry', (data) =>  entry.do(data, io, socket, game));
     // クライアントからstartがemitされた時
     socket.on('start', () => start.do(socket, game));
-    //クライアントからstory_selectionがemitされた時
+    // クライアントからstory_selectionがemitされた時
     socket.on('story_selection', (data) => story_selection.do(socket, io, data.message,data.masterIndex, game));
-    //クライアントからstory_selectionがemitされた時
+    // クライアントからstory_selectionがemitされた時
     socket.on('others_hand_selection', (data) => others_hand_selection.do(socket, io, data.index, game));
-    //クライアントからfield_selecitonがemitされた時
+    // クライアントからfield_selecitonがemitされた時
     socket.on('field_selection', (data) => field_selection.do(socket, data.index, game));
-    //クライアントからfield_selecitonがemitされた時
+    // クライアントからfield_selecitonがemitされた時
     socket.on('calc_score', () => calc_score.do(socket, game));
-    //クライアントからfield_selecitonがemitされた時
+    // クライアントからfield_selecitonがemitされた時
     socket.on('round_end', () => round_end.do(socket, game));
 
     // 通信終了時(ブラウザを閉じる/リロード/ページ移動)
     // TODO: つまりリロードすると復帰不可
-    socket.on('disconnect', () => disconnect.do(io, socket, game));
+    socket.on('disconnect', (reason) => disconnect.do(io, socket, game, reason));
     // メッセージ用
     socket.on('chat_send_from_client', function(data) {
         let name = 'ゲスト';
@@ -62,25 +62,26 @@ io.on('connection', function(socket) {
     });
 });
 
-setInterval(function() {
+setInterval(() => {
     // 全プレイヤーがステージ移行可能ならば移行する
     if (game.isAllDone()) { // 全てのプレイヤーが次のステージにいける状態
         game.nextStage(io);
     }
-    // プレイヤーの状態をemit
-    // io.sockets.emit('state', players);
 }, 1000/30);
 
-app.use('/', express.static(__dirname + '/src'));
+// app.use('/', express.static(__dirname + '/src'));
+// io.use((socket, next) => {
+    // console.log(socket.request);
+// });
 
 // HTTPサーバを生成する
 // サーバー生成時にfunction以下のリクエストリスナーが登録されるため
 // クライアントからHTTPリクエストが送信されるたびにfunctionが実行される
 // ここではヘッダ出力(writeHead)とindex.htmlの出力(readFileSync)
-app.get('/', (request, response) => {
-  response.sendFile(path.join(__dirname, '/src/index.html'));
-});
+// app.post('/', (request, response) => {
+//     response.sendFile(path.join(__dirname, '/src/index.html'));
+// });
 
-server.listen(4001, function() {
+server.listen(4001, () => {
   utils.log('Starting server on port 4001');
 });

--- a/backend/src/scripts/player.js
+++ b/backend/src/scripts/player.js
@@ -1,7 +1,6 @@
 'use strict';
 // import modules
 const Hand = require('./hand');
-const Card = require('./card');
 
 // プレイヤークラス
 class Player {

--- a/backend/src/scripts/stage/disconnect.js
+++ b/backend/src/scripts/stage/disconnect.js
@@ -6,9 +6,11 @@ class Disconnect {
 
     constructor() {}
 
-    static do(io, socket, game) {
-        game.deletePlayer(socket.id);
-        utils.log('Delete [' + socket.id + ']');
+    static do(io, socket, game, reason) {
+        // game.deletePlayer(socket.id);
+        utils.logWithStage(game.stage, 'Delete [' + socket.id + ']');
+        console.log(reason);
+        io.to(socket.id).emit('connect');
         io.sockets.emit('update_number_of_player', {num : game.players.length});
     }
 }

--- a/backend/src/scripts/stage/entry.js
+++ b/backend/src/scripts/stage/entry.js
@@ -10,6 +10,7 @@ class Entry {
         if (game.getLength() < 3) { // プレイヤー人数が3人未満の時
             // プレイヤー追加
             let player = game.addPlayer(data, socket);
+            console.log(socket.handshake.quey);
             // 全クライアントのプレイヤー人数表示更新
             io.sockets.emit('update_number_of_player', {num : game.getLength()});
             utils.logWithStage('entry', 'Player Name: [' + player.name + '] ([' 

--- a/backend/src/scripts/stage/init.js
+++ b/backend/src/scripts/stage/init.js
@@ -1,18 +1,27 @@
 // init
 
 const utils = require('../utils');
+const cookie = require('cookies');
 
 class Init {
 
-    constructor() {}
+    constructor() { }
 
     static do(config, io, socket, game) {
-        io.sockets.emit('update_number_of_player', {num : game.getLength()});
+        io.sockets.emit('update_number_of_player', { num: game.getLength() });
+        console.log(socket.handshake.query);
         if (game.getLength() < 3) { // プレイヤー人数が3人未満のとき
             utils.logWithStage('init', 'socket id: [' + socket.id + '] was added');
-        } else { // 3人より多い場合
-            io.to(socket.id).emit('cannot_play');
-            utils.logWithStage('cannot_play', 'socket ID: [' + socket.id + '] cannot play game.');
+        } else { // 3人以上場合
+            // クエリ(cookie)を取得し，ゲームへの復帰を行う
+            const player = game.findPlayerByName(socket.handshake.query['client-id']);
+            if (typeof player !== 'undefined') {
+                game.comeback(player, socket);
+            } else {
+                console.log('cannot_play');
+                io.to(socket.id).emit('cannot_play');
+                utils.logWithStage('cannot_play', 'socket ID: [' + socket.id + '] cannot play game.');
+            }
         }
     }
 }

--- a/backend/src/scripts/stage/init.js
+++ b/backend/src/scripts/stage/init.js
@@ -1,7 +1,6 @@
 // init
 
 const utils = require('../utils');
-const cookie = require('cookies');
 
 class Init {
 

--- a/backend/src/scripts/stage/round_end.js
+++ b/backend/src/scripts/stage/round_end.js
@@ -4,7 +4,6 @@ const utils = require('../utils');
 class RoundEnd {
 
     static do(socket, game) {
-        game.findPlayer(socket.id).draw(game.stock);
         game.findPlayer(socket.id).done();
     }
 }

--- a/backend/src/scripts/stage/start.js
+++ b/backend/src/scripts/stage/start.js
@@ -4,7 +4,6 @@ const utils = require('../utils');
 class Start {
 
     static do(socket, game) {
-        console.log("fff")
         let player = game.findPlayer(socket.id); // socket IDからプレイヤー特定
         player.done(); // スタート完了
         utils.logWithStage('entry_done', 'socket ID: [' + player.socketId + ']');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1640,6 +1640,11 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1652,6 +1657,15 @@
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -1690,6 +1704,11 @@
       "version": "14.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
       "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -6425,6 +6444,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -10541,6 +10568,16 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.0.3.tgz",
+      "integrity": "sha512-cmi6IpdVgTSvjqssqIEvo779Gfqc4uPGHRrKMEdHcqkmGtPmxolGfsyKj95bhdLEKqMdbX8MLBCwezlnhkHK0g==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -12867,6 +12904,17 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.3.tgz",
+      "integrity": "sha512-YbEHRs7bYOBTIWedTR9koVEe2mXrq+xdjTJZcoKJK/pQaE6ni28ak2AKXFpevb+X6w3iU5SXzWDiJkmpDRb9qw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.4.0",
+        "object-assign": "^4.1.1"
       }
     },
     "universalify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.5.0",
     "jquery": "^3.5.1",
     "react": "^16.13.1",
+    "react-cookie": "^4.0.3",
     "react-dom": "^16.13.1",
     "react-hook-form": "^6.0.7",
     "react-scripts": "3.4.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,13 +9,29 @@ import Init from './scripts/stage/init';
 import Entry from './scripts/stage/entry'
 import Start from './scripts/stage/start';
 import HandSelection from './scripts/stage/hand_selection';
-import socketIOClient from "socket.io-client";
+// import socketIOClient from "socket.io-client";
+import { withCookies } from 'react-cookie';
+import io from 'socket.io-client';
 import FieldSelection from './scripts/stage/field_selection';
 import ShowAnswer from './scripts/stage/show_answer';
 import ShowScore from './scripts/stage/show_score';
 import Result from './scripts/stage/result';
 const ENDPOINT = "http://127.0.0.1:4001/";
-const socket = socketIOClient(ENDPOINT);
+// const socket = socketIOClient(ENDPOINT);
+const socket = io(ENDPOINT, {
+  query: { 'client-id': cookieVal('client-id') },
+  transports: ['websocket'],
+  upgrade: false
+});
+console.log(socket.io.opts.query);
+console.log(document.cookie);
+socket.on('connect_timeout', () => console.log('timeout'));
+socket.on('reconnect', (num) => console.log('reconnect: ' + num));
+socket.on('reconnect_attempt', (num) => console.log('reconnect_attempt: ' + num));
+socket.on('reconnecting', (num) => console.log('reconnecting: ' + num));
+socket.on('reconnect_error', (error) => console.log('reconnect_error: ' + error));
+socket.on('reconnect_failed', () => console.log('reconnect_failed'));
+socket.on('connect_error', (error) => console.log('connect_error: ' + error));
 
 function App() {
 
@@ -37,4 +53,8 @@ function App() {
   );
 }
 
-export default App;
+function cookieVal(key){
+  return ((document.cookie + ';').match(key + '=([^¥S;]*)')||[])[1];
+}
+
+export default withCookies(App);

--- a/frontend/src/scripts/stage/entry.js
+++ b/frontend/src/scripts/stage/entry.js
@@ -1,16 +1,29 @@
-import React, {useState} from 'react';
+import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { useCookies } from 'react-cookie';
 
 export default function Entry(props) {
     /** エントリーフォーム */
     const { register, handleSubmit } = useForm();
     /** エントリーフォームの表示 */
     const [show, setShow] = useState(true);
+    /** cookieの設定 */
+    const [, setCookie] = useCookies(['client-id']);
+
+    useEffect(() => {
+        props.socket.on('start', () => setShow(false));
+        props.socket.on('hand_selection', () => setShow(false));
+        props.socket.on('field_selection', () => setShow(false));
+        props.socket.on('show_answer', () => setShow(false));
+        props.socket.on('show_score', () => setShow(false));
+        props.socket.on('result', () => setShow(false));
+    }, [ props.socket ]);
 
     /** エントリーフォーム入力時の動作 */
     const onSubmit = (data, event) => {
         // サーバーに'entry'を送信
         setShow(false);
+        setCookie('client-id', data.username, {path: '/'});
         props.socket.emit('entry', {username : data.username});
         event.preventDefault(); // フォームによる/?への接続を止める(socketIDを一意に保つため)
     }

--- a/frontend/src/scripts/stage/init.js
+++ b/frontend/src/scripts/stage/init.js
@@ -1,17 +1,24 @@
-import React, {useEffect} from 'react'
+import React, {useEffect, useState} from 'react';
 
 function Init(props) {
+    const [id, setID] = useState(null);
 
     useEffect(() => {
         /** サーバに'init'をemitする */
         const init = (socket) => {
+            setID(socket.id);
             socket.emit('init');
         };
         /** サーバ接続時のイベントハンドラ登録 */
         props.socket.on('connect', () => init(props.socket));
+        props.socket.on('disconnect', (reason) => {
+            if(reason === 'io server disconnect') {
+                props.socket.open();
+            }
+        });
     }, [ props.socket ]);
 
-    return(<div></div>);
+    return(<div>{ id }</div>);
 }
 
 export default Init;

--- a/frontend/src/scripts/stage/start.js
+++ b/frontend/src/scripts/stage/start.js
@@ -19,6 +19,7 @@ export default function Start(props) {
         };
         /** サーバから'start'がemitされたときのイベントハンドラ登録 */
         props.socket.on('start', (data) => start(data.player));
+        props.socket.on('reconnect', (data) => props.socket.io.opts.query = { user: data.name });
     }, [ props.socket ]);
 
     /** スタートボタンを押したときの動作 */


### PR DESCRIPTION
復帰の実装をしました．主な流れは以下

- clientがサーバ接続時(handshakeはHTTP通信，以降はTCP通信．これをwebsocket方式という)にcookieを取得(@App.js/front)
- HTTP通信時にsocketのqueryとしてcookieをサーバに送信(@App.js/front)
- サーバ側で現在のgame上でqueryに合致するplayerを探し，合致するplayerがいれば復帰させる(@init.js/back)

cookieはエントリー時に更新されます

<img src="https://user-images.githubusercontent.com/42469701/88512608-ca9ce700-d021-11ea-8817-c1438a8eaa5a.jpeg" width="400">
<img src="https://user-images.githubusercontent.com/42469701/88512753-00da6680-d022-11ea-8ee8-7cf41c193ee7.jpeg" width="400">

これに伴いいくつかの問題があります

- gameのstageであるhand_selectionがmaster_hand_selectionとstory_selectionとothers_hand_selectionで統合されているため，
    1. masterが手札とお題を決めた後，othersの一人がクラッシュし復帰したとき，復帰したプレイヤーは手札からカードを選べない
    2. masterが手札とお題を決めた後，masterがクラッシュし復帰したとき，masterは手札とお題を選び直す必要あり
- クラッシュした後，復帰してこない場合([issue #22 ](https://github.com/2d-rpg/dixitOnline/issues/22))

他にも

- progressの問題
- result画面後の遷移をどうするか
- すでに接続していて，ゲームが終わるまで待機している人から順番に入れるか
- そもそも１スレッドしかできないってどうかな．．．


以上の問題があります．次のmtg(Fri)でこれらのissueを取り除いた後，日曜のmtgにはUIデザインに進めればと思います