### PR TITLE
hand_selectionの分離と手札の選び直しを可能に (Delevop <- Feature/yoshikawa)

### DIFF
--- a/backend/src/scripts/game.js
+++ b/backend/src/scripts/game.js
@@ -13,10 +13,11 @@ const status = [
     'entry',                 // 0
     'start',                 // 1
     'hand_selection',        // 2
-    'field_selection',       // 3
-    'show_answer',           // 4
-    'show_score',            // 5
-    'result'                 // 6
+    'others_hand_selection', // 3
+    'field_selection',       // 4
+    'show_answer',           // 5
+    'show_score',            // 6
+    'result'                 // 7
 ];
 
 class Game {
@@ -24,7 +25,7 @@ class Game {
     /** ゲーム終了基準点(MAX_SCORE) */
     static MAX_SCORE = 5;
     /** １ラウンドごとのフェイズの数(STAGE_NUM) */
-    static STAGE_NUM = 5;
+    static STAGE_NUM = 6;
     /** カード枚数 */
     static CARD_NUM = 20;
     /** プレイヤー人数 */
@@ -80,7 +81,7 @@ class Game {
         } else {
             this.stageIndex = 2; // hand_selectionへ
             if(this.checkScore()) { // 終了条件
-                this.stageIndex = 6; // result画面へ
+                this.stageIndex = 7; // result画面へ
             }
         }
         if(this.stageIndex == 2){ // hand_selection
@@ -92,7 +93,7 @@ class Game {
             this.players.forEach(player => player.draw(this.stock));
             this.resetAnswers();
         } 
-        if(this.stageIndex == 3){// fieldの更新
+        if(this.stageIndex == 4){// fieldの更新
             this.handToField();
         }
         
@@ -220,6 +221,7 @@ class Game {
             }
         });
         socket.emit(this.stage, {others : others, player : player, game : this});
+        console.log("復帰" + this.stage);
     }
 }
 

--- a/backend/src/scripts/stage/story_selection.js
+++ b/backend/src/scripts/stage/story_selection.js
@@ -10,12 +10,11 @@ class StorySelection {
         game.setMasterClaim(message);
         let player = game.findPlayer(socket.id);
         player.selectFromHand(masterIndex);
-        player.done();
+        //player.done();
+
 
         game.players.forEach(eachPlayer => {
-	        if (player != eachPlayer) {
-                io.to(eachPlayer.socketId).emit('others_hand_selection', {game : game, player : eachPlayer});
-            }
+	        eachPlayer.done()
         });
 	}
 }

--- a/frontend/src/scripts/stage/hand_selection.js
+++ b/frontend/src/scripts/stage/hand_selection.js
@@ -57,7 +57,7 @@ export default function HandSelection(props) {
         const story_selection = (data, index) => {
             setSrc("../images/" + data.player.hand._array[index].filename + ".jpg");
             setSelectedCard(true);
-            setShowHand(false);
+            //setShowHand(false);
             setShowStoryForm(true);
         };
         /** 語り部以外のプレイヤーの手札の表示 */
@@ -102,6 +102,7 @@ export default function HandSelection(props) {
 
     /** お題のフォーム送信ボタンを押したときの動作 */
     const onSubmit = (data, event) => {
+        setShowHand(false);
         setShowStoryForm(false);
         setStory("お題:" + data.story);
         // サーバーに'story_selection'を送信

--- a/frontend/src/scripts/stage/hand_selection.js
+++ b/frontend/src/scripts/stage/hand_selection.js
@@ -62,8 +62,14 @@ export default function HandSelection(props) {
         };
         /** 語り部以外のプレイヤーの手札の表示 */
         const others_hand_selection = (data) => {
-            setStory("お題:" + data.game.masterClaim);
-            setHandButtons(
+            if(data.player.isMaster){
+                props.socket.emit('wait');
+            }else{
+                console.log("others_hand_selectionにきたよ");
+                console.log(data.player.hand);
+                setShowHand(true);
+                setStory("お題:" + data.game.masterClaim);
+                setHandButtons(
                 data.player.hand._array.map((card, index) => {
                     var id = 'hand' + index;
                     var hand_src = "../images/" + card.filename + ".jpg";
@@ -73,6 +79,7 @@ export default function HandSelection(props) {
                     </button>);
                 })
             );
+            }
         };
         /**語り部以外のプレイヤーが手札からカードを選んだときの動作 */
         const others_select = (socket, data, index) => {


### PR DESCRIPTION
## 変更
- hand_selectionを{master_hand_selection , story_selection}と{others_hand_selection}の分離
- 手札の選び直し
