### PR TITLE
ステータス/役割/リザルトのデザイン変更とマッチング待機の表示など

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -43,7 +43,6 @@ io.on('connection', (socket) => {
             if (room != null) {
                 room.game.comeback(player, socket, roomManager);
                 socket.join(room.name);
-                // ToDo : もとのsocket削除
             } else {
                 // entryはしているがroomには入っていない
                 player.socketId = socket.id;

--- a/backend/server.js
+++ b/backend/server.js
@@ -47,7 +47,7 @@ io.on('connection', (socket) => {
             } else {
                 // entryはしているがroomには入っていない
                 player.socketId = socket.id;
-                socket.emit('room',{roomManager:roomManager});
+                socket.emit('room', { roomManager: roomManager });
             }
         } else {
             // entryもしていない

--- a/backend/src/scripts/game.js
+++ b/backend/src/scripts/game.js
@@ -152,7 +152,7 @@ class Game {
         } else {
             this.reset();
         }
-        if (this.stageIndex === status.indexOf('result')){
+        if (this.stageIndex === status.indexOf('result')) {
             this.reset();
             utils.log("game-reset!!");
         }
@@ -168,7 +168,7 @@ class Game {
     }
 
     isFinished() {
-        return this.players.filter(player => player == null).length === this.players.length && this.stageIndex === status.length;
+        return this.players.lenght >= 3 && this.players.filter(player => player == null).length === this.players.length && this.stageIndex === status.length;
     }
 
     /** 語り部の更新 */

--- a/backend/src/scripts/game.js
+++ b/backend/src/scripts/game.js
@@ -152,10 +152,6 @@ class Game {
         } else {
             this.reset();
         }
-        if (this.stageIndex === status.indexOf('result')) {
-            this.reset();
-            utils.log("game-reset!!");
-        }
         utils.log('Move to stage [' + this.stage + ']');
     }
 
@@ -168,7 +164,7 @@ class Game {
     }
 
     isFinished() {
-        return this.players.lenght >= 3 && this.players.filter(player => player == null).length === this.players.length && this.stageIndex === status.length;
+        return this.players.length >= 3 && this.players.filter(player => player == null).length === this.players.length && this.stageIndex === status.length;
     }
 
     /** 語り部の更新 */

--- a/backend/src/scripts/room.js
+++ b/backend/src/scripts/room.js
@@ -14,6 +14,7 @@ class Room {
         this.game = new Game();
         // this.chat = new Chat();
         this.players = [];
+        this.nextGame = new Game();
     }
 
     entry(player) {

--- a/backend/src/scripts/stage/leave.js
+++ b/backend/src/scripts/stage/leave.js
@@ -1,3 +1,5 @@
+const Game = require("../game");
+
 class Leave {
 
     constructor() {}
@@ -9,8 +11,13 @@ class Leave {
         socket.leave(room.name);
         player.reset();
         if (room.players.length > 0) {
-            if(!player.isMaster){
-            }else{
+            if (room.game.players.length === 0) {
+                room.game = room.nextGame;
+                room.nextGame = new Game();
+                io.sockets.emit('update_roomlist', {roomManager:roomManager});
+            }
+            if(!player.isMaster) {
+            } else {
                 // 親の変更
                 room.players[0].isMaster = true;
             }

--- a/backend/src/scripts/stage/room_create.js
+++ b/backend/src/scripts/stage/room_create.js
@@ -12,7 +12,7 @@ class RoomCreate {
         io.sockets.emit('update_number_of_player', {num : roomManager.players.length});
         io.sockets.emit('update_roomlist', {roomManager : roomManager});
         socket.emit('show_start');
-        room_entry.do({roomname:room.name, game:room.game}, io, socket, roomManager);
+        room_entry.do({ roomname: room.name, game: room.game }, io, socket, roomManager);
     }
 
 }

--- a/backend/src/scripts/stage/room_entry.js
+++ b/backend/src/scripts/stage/room_entry.js
@@ -15,8 +15,8 @@ class RoomEntry {
             player.isMaster = true;
         }
         // room.players.forEach(player => console.log(player.socketId));
-        io.to(data.roomname).emit('entry_player', {room: room});
-        io.to(data.roomname).emit('update_player_list', {game: room.game});
+        io.to(data.roomname).emit('entry_player', { room: room });
+        io.to(data.roomname).emit('update_player_list', { game: room.game });
     }
 }
 

--- a/frontend/src/css/result.css
+++ b/frontend/src/css/result.css
@@ -1,7 +1,22 @@
+@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1');
+
 .result-wrapper
 {
     position: absolute;
     width: 100%;
+}
+
+.result-content
+{
+    background-color: #353b48;
+    color: antiquewhite;
+    font-weight: 700;
+    /* font-family: "M PLUS Rounded 1c"; */
+}
+
+.modal-header > .close
+{
+    color: antiquewhite;
 }
 
 table#result-table
@@ -16,7 +31,7 @@ table#result-table
 #result-table tr
 {
     height: 10%;
-    background-color: #f4f6f6;
+    background-color: #576574;
     /* margin: 1%; */
 }
 

--- a/frontend/src/css/room.css
+++ b/frontend/src/css/room.css
@@ -85,12 +85,14 @@
 }
 
 .room-leave {
-    margin-top: 63%;
-    margin-left: 80%;
+    position: absolute;
+    top: 85%;
+    right: 5%;
     border: 2px solid grey;
 }
 
 .matching {
     position: absolute;
+    top: 85%;
     width: 100%;
 }

--- a/frontend/src/css/room.css
+++ b/frontend/src/css/room.css
@@ -84,7 +84,7 @@
     box-shadow: none;
 }
 
-.room-leave{
+.room-leave {
     margin-top: 63%;
     margin-left: 80%;
     border: 2px solid grey;

--- a/frontend/src/css/room.css
+++ b/frontend/src/css/room.css
@@ -89,3 +89,8 @@
     margin-left: 80%;
     border: 2px solid grey;
 }
+
+.matching {
+    position: absolute;
+    width: 100%;
+}

--- a/frontend/src/css/show_answer.css
+++ b/frontend/src/css/show_answer.css
@@ -79,6 +79,9 @@ span.score-diff-name
     display: inline-block;
     margin: 1%;
     width: 15%;
+    color: white;
+    font-weight: 600;
+    border-radius: 10px;
 }
 
 .field-cards-result
@@ -135,7 +138,8 @@ span.score-diff-name
 {
     display: inline-flex;
     flex-direction: row;
-    text-align: center;
+    vertical-align: bottom;
+    /* text-align: center; */
     margin: 1%;
 }
 .eachOwnerNames
@@ -153,13 +157,13 @@ span.score-diff-name
 .eachOwnerName
 {
     /* height: 30%; */
-    line-height: 30%;
-    margin: 5%;
+    line-height: 100%;
+    /* margin: 5%; */
     margin-left: 15%;
     margin-right: 15%;
     border: solid;
-    background-color: #00BFFF;
-    border-color: #00BFFF;
+    /* background-color: #00BFFF;
+    border-color: #00BFFF; */
     border-radius: 10px;
     font-size: 10px;
     font-weight: bold;
@@ -168,23 +172,22 @@ span.score-diff-name
     flex-direction: column;
 }
 
-.eachOwnerName.master
+.eachOwnerName.correct
 {
     background-color: #FF00FF;
     border-color: #FF00FF;
 }
 
-
 .eachName
 {
     /* height: 30%; */
-    line-height: 30%;
-    margin: 5%;
+    line-height: 100%;
+    /* margin: 5%; */
     margin-left: 15%;
     margin-right: 15%;
     border: solid;
-    background-color: blueviolet;
-    border-color: blueviolet;
+    /* background-color: blueviolet; */
+    /* border-color: blueviolet; */
     border-radius: 10px;
     font-size: 10px;
     font-weight: bold;

--- a/frontend/src/css/show_role.css
+++ b/frontend/src/css/show_role.css
@@ -3,20 +3,28 @@
     /* margin: 0; */
     /* padding-right: 13%; */
     position: absolute;
-    right: 0.7%;
-    bottom: 7%;
+    right: 0;
+    bottom: 6%;
+    margin: 0.5%;
     /* margin-top: 50%; */
     height: 20%; 
     width: 14%; 
-    background-color: gray;
-    border: solid 3px #6091d3;/*線*/
-    border-radius: 20px;/*角の丸み*/
+    background-color: #2C3A47;
+    /* border: solid 3px #6091d3;線 */
+    /* border-radius: 20px;角の丸み */
+    border: 25px solid #B88846;
+    border-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='75' height='75'%3E%3Cg fill='none' stroke='%23B88846' stroke-width='2'%3E%3Cpath d='M1 1h73v73H1z'/%3E%3Cpath d='M8 8h59v59H8z'/%3E%3Cpath d='M8 8h16v16H8zM51 8h16v16H51zM51 51h16v16H51zM8 51h16v16H8z'/%3E%3C/g%3E%3Cg fill='%23B88846'%3E%3Ccircle cx='16' cy='16' r='2'/%3E%3Ccircle cx='59' cy='16' r='2'/%3E%3Ccircle cx='59' cy='59' r='2'/%3E%3Ccircle cx='16' cy='59' r='2'/%3E%3C/g%3E%3C/svg%3E") 25;
 }
 
-.role-figure{
+.role-container {
+    align-items: center;
+}
+
+.role-figure {
     /* border: solid 3px #6091d3;線 */
-    margin-left:5%;
-    margin-right:5%;
+    /* margin-left:5%;
+    margin-right:5%; */
+    /* margin: auto; */
 }
 
 .text

--- a/frontend/src/css/status.css
+++ b/frontend/src/css/status.css
@@ -1,14 +1,76 @@
+@import url('https://fonts.googleapis.com/css?family=Merriweather');
+
 .player-status
 {
     position: absolute;
-    top: 75%;
-    width: 13%;
-    color: #666666; /*文字色*/
-    border: 2px solid #996633; /*線の太さ・色*/
-    background-color: #fff; /*背景色*/
-    box-shadow: -2px 5px 5px #e8d3c7; /*影*/
-    border-radius: 20px; /*角の丸み*/ 
-    margin: 1%;
-    padding: 1%;
+    /* top: 75%; */
+    bottom: 6%;
+    height: 20%;
+    width: 14%;
+    margin: 0.5%;
+    /* padding: 1%; */
     font-size: small;
+    background: #3A3D3E;
+    color: white;
+    font-family: Merriweather;
+}
+
+.outer-border {
+	border: 1px solid #DE9B72;
+   	height: 99%;
+    width: 98%;
+    padding: 2px;
+    margin: 0 auto;
+}
+
+.mid-border {
+    border: 2px solid #DE9B72;
+    height: 100%;
+    width: 100%;
+    padding: 2px;
+    margin: auto;
+}
+
+.inner-border {
+	position: relative;
+	border: 1px solid #DE9B72;
+    height: 100%;
+    width: 100%;
+    margin: auto;
+}
+
+.corner-decoration {
+	position: absolute;
+    width: 2em;
+    margin: -2px;
+}
+
+.corner-decoration.corner-left-top {
+	left: 0;
+	top: 0;
+}
+
+.corner-decoration.corner-right-top {
+	top: 0;
+	right: 0;
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+}
+
+.corner-decoration.corner-right-bottom {
+	right: 0;
+	bottom: 0;
+    -webkit-transform: scale(-1);
+  	transform: scale(-1);
+}
+
+.corner-decoration.corner-left-bottom {
+	left: 0;
+	bottom: 0;
+	-webkit-transform: scaleY(-1);
+  	transform: scaleY(-1);
+}
+
+.player-status-container {
+    margin-top: 15%;
 }

--- a/frontend/src/scripts/leave.js
+++ b/frontend/src/scripts/leave.js
@@ -1,10 +1,9 @@
 
 import React, { useState, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
 import '../css/upload.css';
 
 export default function Upload(props) {
-    /** エントリーフォームの表示 */
+    /** 退室ボタンの表示 */
     const [showLeave, setShowLeave] = useState(false);
 
     const className = "btn btn-warning mb-2 " + props.className;
@@ -16,7 +15,7 @@ export default function Upload(props) {
         props.socket.on('entry_player', (data) => setShowLeave(true));
         props.socket.on('in_room', (data) => setShowLeave(true));
         props.socket.on('result' ,(data) => setShowLeave(true));
-        props.socket.on('restart' ,(data) => setShowLeave(false));
+        props.socket.on('restart' ,(data) => setShowLeave(true));
     }, [ props.socket, setShowLeave ]);
 
     const handleleave = () => {

--- a/frontend/src/scripts/leave.js
+++ b/frontend/src/scripts/leave.js
@@ -28,8 +28,8 @@ export default function Upload(props) {
     }
 
     return (
-        <button onClick={ handleleave } id="create-room-button" style={ {display: showLeave ? 'block' : 'none' } } className={ className } >
-            ルームを退出
+        <button onClick={ handleleave } id="leave-room-button" style={ {display: showLeave ? 'block' : 'none' } } className={ className } >
+            ルーム退室
         </button>
     );
 }

--- a/frontend/src/scripts/matching.js
+++ b/frontend/src/scripts/matching.js
@@ -1,0 +1,24 @@
+import { data } from 'jquery';
+import React, { useState, useEffect } from 'react';
+
+export default function Matching(props) {
+
+    /** マッチングの表示 */
+    const [showMatching, setShowMatching] = useState(false);
+
+    useEffect(() => {
+        props.socket.on('update_player_list', (data) => {
+            setShowMatching(true);
+        });
+        props.socket.on('hand_selection', () => setShowMatching(false));
+    });
+
+    return(
+        <div class="text-center matching" style={ { display: showMatching ? 'block' : 'none' } }>
+            <button class="btn btn-primary" type="button" disabled>
+                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                マッチング中...
+            </button>
+        </div>
+    )
+}

--- a/frontend/src/scripts/matching.js
+++ b/frontend/src/scripts/matching.js
@@ -10,6 +10,7 @@ export default function Matching(props) {
         props.socket.on('update_player_list', (data) => {
             setShowMatching(true);
         });
+        props.socket.on('room', () => setShowMatching(false));
         props.socket.on('hand_selection', () => setShowMatching(false));
     });
 

--- a/frontend/src/scripts/player_name.js
+++ b/frontend/src/scripts/player_name.js
@@ -4,7 +4,7 @@ export default function PlayerName(props) {
 
     return (
         <div className="player-name">
-            <div>プレイヤー名</div>
+            <div>NAME</div>
             <p>{ props.name }</p>
         </div>);
 }

--- a/frontend/src/scripts/stage/entry.js
+++ b/frontend/src/scripts/stage/entry.js
@@ -17,13 +17,17 @@ export default function Entry(props) {
     const [, setCookie] = useCookies(['client-id']);
 
     useEffect(() => {
+        const comeback = (name) => {
+            setShow(false);
+            props.setName(name);
+        };
         props.socket.on('room', () => setShow(false));
-        props.socket.on('in_room', () => setShow(false));
-        props.socket.on('hand_selection', () => setShow(false));
-        props.socket.on('others_hand_selection', () => setShow(false));
-        props.socket.on('field_selection', () => setShow(false));
-        props.socket.on('show_answer', () => setShow(false));
-        props.socket.on('result', () => setShow(false));
+        props.socket.on('in_room', (data) => comeback(data.player.name));
+        props.socket.on('hand_selection', (data) => comeback(data.player.name));
+        props.socket.on('others_hand_selection', (data) => comeback(data.player.name));
+        props.socket.on('field_selection', (data) => comeback(data.player.name));
+        props.socket.on('show_answer', (data) => comeback(data.player.name));
+        props.socket.on('result', (data) => comeback(data.player.name));
         // props.socket.on('restart', () => setShow(true));
     }, [ props.socket ]);
 

--- a/frontend/src/scripts/stage/hand_selection.js
+++ b/frontend/src/scripts/stage/hand_selection.js
@@ -167,6 +167,7 @@ export default function HandSelection(props) {
         props.socket.on('result',(data) => update_hand(data.player));
         props.socket.on('restart',() => setShowHand(false));
         props.socket.on('room',() => setShowHand(false));
+        props.socket.on('in_room', () => setShowHand(false));
     }, [ props.socket, props.setMessage, props.setSrc ]);
 
     return (

--- a/frontend/src/scripts/stage/result.js
+++ b/frontend/src/scripts/stage/result.js
@@ -70,7 +70,7 @@ export default function Result(props) {
     return(
         <div className="modal fade" id="resultModalWindow" tabindex="-1" role="dialog" aria-labelledby="resultModalTitle" aria-hidden="true">
             <div className="modal-dialog modal-dialog-centered" id="resultModalDialog" role="document">
-                <div className="modal-content">
+                <div className="modal-content result-content">
                     <div className="modal-header">
                         <h5 className="modal-title" id="resultModalTitle">結果</h5>
                         <button type="button" class="close" onClick={ handleclick } aria-label="Close">
@@ -90,8 +90,8 @@ export default function Result(props) {
                         </table>
                     </div>
                     <div className="modal-footer">
-                        <button id="backButton" onClick={ handleclick } type="button" className="btn btn-warning m-auto">戻る</button>
-                        <Leave socket= { props.socket } handle={ handleclick } className="result-leave"/>
+                        <button id="backButton" onClick={ handleclick } type="button" className="btn btn-warning m-auto">もう一度</button>
+                        <Leave socket= { props.socket } handle={ handleclick } className="result-leave m-auto"/>
                     </div>
                 </div>
             </div>

--- a/frontend/src/scripts/stage/room.js
+++ b/frontend/src/scripts/stage/room.js
@@ -98,6 +98,8 @@ export default function Room(props) {
         // props.socket.on('room_create', () => setShowRoom(false));
         props.socket.on('update_roomlist', (data) => updateRoomList(data.roomManager));
         props.socket.on('entry_player', (data) => {
+            console.log(data.room.game.players.length);
+            console.log(data.room.nextGame.players.length);
             if (data.room.game.players.length > 2 && data.room.game.players[0].socketId === props.socket.id) setShowStart(true);
         });
         props.socket.on('update_player_list', (data) => {

--- a/frontend/src/scripts/stage/room.js
+++ b/frontend/src/scripts/stage/room.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Leave from '../leave';
 import '../../css/room.css';
+import Matching from '../matching';
 
 
 const audio = new Audio('../audio/decision29low.wav');
@@ -9,7 +10,7 @@ audio.volume = 0.1;
 
 export default function Room(props) {
 
-    const { register, handleSubmit } = useForm();
+    const { register, handleSubmit, reset } = useForm();
 
     const [showRoom, setShowRoom] = useState(false);
 
@@ -27,7 +28,7 @@ export default function Room(props) {
 
     const roomEntrySubmit = (roomname) => {
         audio.play();
-        setShowRoom(false);
+        setShowRoomContent(false);
         props.setShowStatus(true);
         props.socket.emit('room_entry', {roomname : roomname});
         props.setMessage('他のプレイヤーが参加するのを待っています( ´ ▽ ` )');
@@ -39,6 +40,7 @@ export default function Room(props) {
         setShowRoomContent(false);
         props.setShowStatus(true);
         props.socket.emit('room_create', {username : data.username, roomname : data.roomname});
+        reset();
         event.preventDefault(); // フォームによる/?への接続を止める(socketIDを一意に保つため)
         props.setMessage('他のプレイヤーが参加するのを待っています( ´ ▽ ` )');
     }
@@ -98,6 +100,11 @@ export default function Room(props) {
         props.socket.on('entry_player', (data) => {
             if (data.room.game.players.length > 2 && data.room.game.players[0].socketId === props.socket.id) setShowStart(true);
         });
+        props.socket.on('update_player_list', (data) => {
+            if (data.game.players.length < 3) {
+                setShowStart(false);
+            }
+        });
         props.socket.on('restart', () => {
             setShowRoomContent(false);
             setShowRoomCreate(false);
@@ -121,7 +128,7 @@ export default function Room(props) {
                     <div className="room-create-title">ルーム名を決めてください</div>
                     <form className="form-inline" id="roomCreateForm" onSubmit={ handleSubmit(roomCreateSubmit) }>
                         <label className="sr-only" htmlFor="inlineFormInputName2">Name</label>
-                        <input type="text" className="form-control mb-2 mr-sm-2" name="roomname" ref={ register } placeholder="ルーム名"/>
+                        <input type="text" className="form-control mb-2 mr-sm-2" name="roomname" ref={ register() } placeholder="ルーム名"/>
                         <button type="submit" className="btn btn-primary mb-2">決定</button>
                     </form>
                 </div>
@@ -144,6 +151,7 @@ export default function Room(props) {
                     このメンバーでゲーム開始
                 </button>
             </div>
+            <Matching socket={ props.socket }/>
             <Leave className="room-leave" socket= { props.socket }/>
         </div>
     );

--- a/frontend/src/scripts/stage/show_answer.js
+++ b/frontend/src/scripts/stage/show_answer.js
@@ -8,6 +8,14 @@ import '../../css/show_answer.css';
 const audio = new Audio('../audio/decision29low.wav');
 audio.volume = 0.1;
 
+const playerColors = [ 
+    { 'background-color': '#2ed573' }, 
+    { 'background-color': '#00BFFF' }, 
+    { 'background-color': '#ffa502' }, 
+    { 'background-color': '#ff3838' }, 
+    { 'background-color': '#ff6348' } 
+];
+
 export default function ShowAnswer(props) {
     /** モーダルのタイトル */
     const [message, setMessage] = useState(null);
@@ -19,6 +27,8 @@ export default function ShowAnswer(props) {
     const [selectedNames, setSelectedNames] = useState(null);
     /** フィールドを選んだプレイヤーの表示内容 */
     const [ownerNames, setOwnerNames] = useState(null);
+    /** フィールドを選んだプレイヤーの表示の最大値 */
+    const [maxHeight, setMaxHeight] = useState(null);
 
 
     useEffect(() => {
@@ -47,7 +57,7 @@ export default function ShowAnswer(props) {
                     var id_score_diff = 'eachScoreDiff' + index;
                     return(
                         <div className='eachScoreDiff' id={ id_score_diff }>
-                            <span className="score-diff-name">{ player.name }</span>
+                            <span className="score-diff-name" style={ playerColors[data.game.players.indexOf(player)] }>{ player.name }</span>
                             <span>{ player.prescore }</span>
                             <FontAwesomeIcon className="role-figure" style={ iconStyle }  icon={ faLongArrowAltRight }/>
                             <span>{ player.score }</span>
@@ -63,11 +73,15 @@ export default function ShowAnswer(props) {
                             player.socketId === card.player
                     ).map((player, indexplayer) => {
                         const id = "eachName" + index + "player" + indexplayer;
-                        return (<div className={player.isMaster ? "eachOwnerName master" : "eachOwnerName"} id={ id }>{ player.name }</div>);
+                        const eachName = <div className={player.isMaster ? "eachOwnerName master" : "eachOwnerName"} style={ playerColors[data.game.players.indexOf(player)] } id={ id }>{ player.name }</div>;
+                        const ret = player.isMaster ? [eachName, <div className="eachOwnerName correct">正解</div>] : eachName;
+                        return (ret);
                     });
                     return (<div className="eachOwnerNames" id={ id_lst }>{ name }</div>);
                 })
             );
+            // 高さの設定
+            setMaxHeight(Math.max(...[3, ...data.game.field.cards.map(card => data.game.players.filter(player => player.socketId === card.player).length)]));
             // 投票結果のフィールドの表示セット
             setFieldCards(
                 data.game.field.cards.map((card, index) => {
@@ -90,7 +104,7 @@ export default function ShowAnswer(props) {
                         data.game.answers.filter(element => element.cardIndex === index).some(element => element.id === player.socketId)
                     ).map((player, indexplayer) => {
                         const id = "eachName" + index + "player" + indexplayer;
-                        return (<div className="eachName" id={ id }>{ player.name }</div>);
+                        return (<div className="eachName" id={ id } style={ playerColors[data.game.players.indexOf(player)] }>{ player.name }</div>);
                     });
                     return (<div className="eachSelectedNames" id={ id_lst }>{ names }</div>);
                 })
@@ -123,7 +137,7 @@ export default function ShowAnswer(props) {
                             <div className="show-answer-selected-cards">
                                 <div className="field-result-wrapper">
                                     <p>投票結果</p>
-                                    <div id="owner-field">{ ownerNames }</div>
+                                    <div id="owner-field" style={ { 'height': `${maxHeight * 10}px` } }>{ ownerNames }</div>
                                     <div className="field-cards-result">{ fieldCards }</div>
                                     <div id="selected-field">{ selectedNames }</div>
                                 </div>

--- a/frontend/src/scripts/stage/show_role.js
+++ b/frontend/src/scripts/stage/show_role.js
@@ -11,7 +11,7 @@ export default function ShowRole(props) {
     /** プレイヤーのロール */
     const [isMaster, setIsMaster] = useState(null);
 
-    const iconStyle =  { 'margin-right': 20,'margin-left': 20, 'width': 80, 'height': 80 };
+    const iconStyle =  { 'width': 60, 'height': 60 };
 
     useEffect(() => {
         /** スコアの表示 */
@@ -40,8 +40,10 @@ export default function ShowRole(props) {
 
     return(
     <div className="role-wrapper" style={ { textAlign: "center", display: showrole ? 'block' : 'none', padding: "50" } } >
-      <FontAwesomeIcon className="role-figure" style={ iconStyle }  icon={ isMaster ? faChessRook : faChessPawn } color={ isMaster ? "gold" : "seashell" }/>
-      <span className="text">{ isMaster ? "語り部" : "聞き手" }</span>
+        <div className="role-container">
+            <FontAwesomeIcon className="role-figure" style={ iconStyle }  icon={ isMaster ? faChessRook : faChessPawn } color={ isMaster ? "gold" : "seashell" }/>
+            <span className="text">{ isMaster ? "語り部" : "聞き手" }</span>
+        </div>
     </div>
     );
 }

--- a/frontend/src/scripts/stage/show_score.js
+++ b/frontend/src/scripts/stage/show_score.js
@@ -16,7 +16,7 @@ export default function ShowScore(props) {
     return(
         <div id="score">
             <div>SCORE</div>
-            <div>{ score }点</div>
+            <div>{ score }</div>
         </div>
     );
 }

--- a/frontend/src/scripts/stage/show_score.js
+++ b/frontend/src/scripts/stage/show_score.js
@@ -11,6 +11,7 @@ export default function ShowScore(props) {
         }
         /** サーバからemitされたときのイベントハンドラ一覧 */
         props.socket.on('show_answer', (data) => show_score(data));
+        props.socket.on('restart', () => setScore(0));
     }, [ props.socket ]);
 
     return(

--- a/frontend/src/scripts/status.js
+++ b/frontend/src/scripts/status.js
@@ -18,7 +18,19 @@ export default function Status(props) {
 
     return (
         <div className="player-status" style={ {display: props.showStatus ? 'block' : 'none'} }>
-            <PlayerName name={ props.name }/>
-            <ShowScore socket={ props.socket }/>
+            <div className="outer-border">
+                <div className="mid-border">
+                    <div className="inner-border">
+                        <img className="corner-decoration corner-left-top" src="https://i.ibb.co/4mKvK3N/corner-decoration.jpg"/> 
+                        <img className="corner-decoration corner-right-top" src="https://i.ibb.co/4mKvK3N/corner-decoration.jpg"/>
+                        <img className="corner-decoration corner-right-bottom" src="https://i.ibb.co/4mKvK3N/corner-decoration.jpg"/>
+                        <img className="corner-decoration corner-left-bottom" src="https://i.ibb.co/4mKvK3N/corner-decoration.jpg"/>
+                        <div className="player-status-container">
+                            <PlayerName name={ props.name }/>
+                            <ShowScore socket={ props.socket }/>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>);
 }

--- a/frontend/src/scripts/status.js
+++ b/frontend/src/scripts/status.js
@@ -6,7 +6,7 @@ import '../css/status.css';
 export default function Status(props) {
 
     useEffect(() => {
-        props.socket.on('restart',() => props.setShowStatus(false));
+        props.socket.on('restart',() => props.setShowStatus(true));
         props.socket.on('in_room',() => props.setShowStatus(true));
         props.socket.on('hand_selection',() => props.setShowStatus(true));
         props.socket.on('others_hand_selection',() => props.setShowStatus(true));

--- a/frontend/src/scripts/upload.js
+++ b/frontend/src/scripts/upload.js
@@ -32,6 +32,9 @@ export default function Upload(props) {
             setShow(true);
             update(data);
         });
+        props.socket.on('room', () => {
+            setShow(false);
+        });
         props.socket.on('in_room', (data) => {
             setShow(true);
             update(data);


### PR DESCRIPTION
修正箇所は以下

- ステータス/役割/リザルトのデザイン変更
- マッチング待機の表示
- マッチング中に3人から2人に減ったときにスタートできなくなるように変更
- 復帰時のプレイヤー名の表示修正
- 退室時にファイルのアップロードフォームが消えるよう修正

![スクリーンショット 2020-09-21 2 26 40](https://user-images.githubusercontent.com/42469701/93717621-ebad2e80-fbb1-11ea-826c-677b6c70811b.png)

@wabetarou @nonofefe 次回は，このプルリクを先にdevelopにマージして，その後PR #61の方を更新後，退室の動作などが正常に動くのを確認してから更新したPR #61をdevelopにマージして，GCP上で動作確認します．